### PR TITLE
Support Linux path reading, add Qwen no-thought tag

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,14 @@ from datetime import datetime
 from src.plugins.manager import get_plugin_manager
 from src.interfaces.yolo_interface import load_yolo_model
 import mimetypes
+import platform
+import pathlib
+
+# 全局 monkey-patch: 兼容 WindowsPath pickle 权重在 Linux 加载
+if platform.system() == 'Windows':
+    pathlib.PosixPath = pathlib.WindowsPath
+else:
+    pathlib.WindowsPath = pathlib.PosixPath
 
 # 显式地为 .js 文件添加正确的 MIME 类型
 # Flask/Werkzeug 在服务静态文件时通常会参考这个

--- a/src/app/static/js/high_quality_translation.js
+++ b/src/app/static/js/high_quality_translation.js
@@ -530,6 +530,7 @@ async function callAiForTranslation(imageBase64Array, jsonData, provider, apiKey
     const noThinkingMethod = state.hqNoThinkingMethod || 'gemini';
     
     // 根据不同取消思考方法添加参数
+        // 根据不同取消思考方法添加参数
     if (lowReasoning) {
         if (noThinkingMethod === 'gemini') {
             // Gemini风格：使用reasoning_effort参数
@@ -539,6 +540,9 @@ async function callAiForTranslation(imageBase64Array, jsonData, provider, apiKey
             // 火山引擎风格：设置thinking=null
             apiParams.thinking = null;
             console.log("使用火山引擎方式取消思考: thinking=null");
+        } else if (noThinkingMethod === 'qwen') {
+            apiParams.think = false;
+            console.log("使用千文方式取消思考: think=false");
         } else {
             // 默认使用Gemini风格
             apiParams.reasoning_effort = "low";
@@ -875,6 +879,7 @@ export function initHqTranslationUI() {
         <select id="hqNoThinkingMethod">
             <option value="gemini" ${state.hqNoThinkingMethod === 'gemini' ? 'selected' : ''}>Gemini (reasoning_effort)</option>
             <option value="volcano" ${state.hqNoThinkingMethod === 'volcano' ? 'selected' : ''}>火山引擎 (thinking: null)</option>
+            <option value="qwen" ${state.hqNoThinkingMethod === 'qwen' ? 'selected' : ''}>Qwen3 (\\no_think)</option>
         </select>
     </div>`;
     

--- a/src/interfaces/yolo_interface.py
+++ b/src/interfaces/yolo_interface.py
@@ -1,3 +1,5 @@
+from pathlib import PosixPath
+import pickle
 import torch
 import os
 import logging
@@ -55,15 +57,31 @@ def load_yolo_model(weights_name='best.pt', repo_dir_name='ultralytics_yolov5_ma
             return None
 
         logger.info(f"开始加载 YOLOv5 模型: {weights_path}")
+        
+        orig_unpickler = pickle._Unpickler if hasattr(pickle, "_Unpickler") else pickle.Unpickler
+        orig_find_class = orig_unpickler.find_class
+
+        def patched_find_class(self, module, name):
+            if module == "pathlib" and name == "WindowsPath":
+                return PosixPath
+            return orig_find_class(self, module, name)
+
+        orig_unpickler.find_class = patched_find_class
+
+        
         # 强制重新加载，避免缓存问题，并指定本地源
         # 使用 trust_repo=True (如果你的 torch 版本支持) 或适应旧版 API
         try:
-             # 尝试使用 trust_repo=True (适用于较新版本 PyTorch Hub)
-             _yolo_model = torch.hub.load(repo_or_dir=repo_dir, model='custom', path=weights_path, source='local', force_reload=False, trust_repo=True)
-        except TypeError:
-             # 回退到旧版 API (没有 trust_repo 参数)
-             logger.warning("当前 PyTorch Hub 版本不支持 trust_repo=True，尝试旧版 API。")
-             _yolo_model = torch.hub.load(repo_or_dir=repo_dir, model='custom', path=weights_path, source='local', force_reload=False)
+            # 尝试使用 trust_repo=True (适用于较新版本 PyTorch Hub)
+            _yolo_model = torch.hub.load(repo_or_dir=repo_dir, model='custom', path=weights_path, source='local', force_reload=False, trust_repo=True)
+        except Exception as e:
+            logger.error(f"加载 YOLOv5 模型失败: {e}", exc_info=True)
+            #  # 回退到旧版 API (没有 trust_repo 参数)
+            logger.warning("当前 PyTorch Hub 版本不支持 trust_repo=True，尝试旧版 API。")
+            _yolo_model = torch.hub.load(repo_or_dir=repo_dir, model='custom', path=weights_path, source='local', force_reload=False)
+        finally:
+            # 恢复原始 find_class，避免影响全局
+            orig_unpickler.find_class = orig_find_class
 
 
         _yolo_model.conf = conf_threshold


### PR DESCRIPTION
1. 移植过程发现Yolo5文件无法读取，因为平台不同，目前强制兼容但是不推荐。
2. 增加了Qwen3 no_thnk 的tag

ps. 额外建议，翻译中尝试传输webp而不是png节省带宽。